### PR TITLE
Fixed. `go vet` is failed on golang 1.10

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -3,7 +3,7 @@
 # If you want Google's container you would reference google/golang
 # Read more about containers on our dev center
 # http://devcenter.wercker.com/docs/containers/index.html
-box: golang
+box: golang:1.9
 # This is the build pipeline. Pipelines are the core of wercker
 # Read more about pipelines on our dev center
 # http://devcenter.wercker.com/docs/pipelines/index.html


### PR DESCRIPTION
```
$ go version
go version go1.10 darwin/amd64

$ go vet
# errors
compile: version "go1.9.3" does not match go tool version "go1.10"
go tool asm: exit status 2
flag provided but not defined: -V
usage: asm [options] file.s ...
Flags:
  -D value
    	predefined symbol with optional simple value -D=identifier=value; can be set multiple times
  -I value
    	include directory; can be set multiple times
  -S	print assembly and machine code
  -debug
    	dump instructions as they are parsed
  -dynlink
    	support references to Go symbols defined in other shared libraries
  -e	no limit on number of errors reported
  -o string
    	output file; default foo.o for /a/b/c/foo.s as first argument
  -shared
    	generate code that can be linked into a shared library
  -trimpath string
    	remove prefix from recorded source file paths
```

It seems this error.
ttps://github.com/golang/go/issues/23986